### PR TITLE
dont not create PDf file if downloadUrl not return 200

### DIFF
--- a/ovh-download-invoice.go
+++ b/ovh-download-invoice.go
@@ -140,7 +140,7 @@ func downloadInvoices(c *cli.Context) error {
 				if _, err := os.Stat(file); err != nil {
 					if os.IsNotExist(err) {
 						resp, err := http.Get(deposit.PdfURL)
-						if err == nil {
+						if err == nil && resp.StatusCode == 200 {
 							f, err := os.Create(file)
 							if err == nil {
 								io.Copy(f, resp.Body)
@@ -213,7 +213,7 @@ func downloadInvoices(c *cli.Context) error {
 				if _, err := os.Stat(file); err != nil {
 					if os.IsNotExist(err) {
 						resp, err := http.Get(bill.PdfURL)
-						if err == nil {
+						if err == nil && resp.StatusCode == 200 {
 							f, err := os.Create(file)
 							if err == nil {
 								io.Copy(f, resp.Body)
@@ -251,7 +251,7 @@ func downloadInvoices(c *cli.Context) error {
 				if _, err := os.Stat(file); err != nil {
 					if os.IsNotExist(err) {
 						resp, err := http.Get(refund.PdfURL)
-						if err == nil {
+						if err == nil && resp.StatusCode == 200 {
 							f, err := os.Create(file)
 							if err == nil {
 								io.Copy(f, resp.Body)


### PR DESCRIPTION
Sometime, the PDF to download is not available yet, and the PDF create containt the HTML page 404, instead of the PDF content.

Before this patch, i just delete the bad PDF and the next day, it can be recreate (i use a crontab).
With this patch, the bad PDF is not created, and the next day it, if content is a PDF? it can be created. 